### PR TITLE
Add include directories for fplll to dependent CMake targets

### DIFF
--- a/src/problems/lattice_reduction/CMakeLists.txt
+++ b/src/problems/lattice_reduction/CMakeLists.txt
@@ -27,3 +27,7 @@ target_link_libraries(flatter
   PUBLIC
     ${FPLLL_LIBRARIES}
 )
+target_include_directories(flatter
+  PRIVATE
+    ${FPLLL_INCLUDE_DIRS}
+)


### PR DESCRIPTION
See title. The include path for`<fplll/fplll.h>` was never passed to relevant targets — only the library was linked.

Tested via
```bash
git clone https://github.com/fplll/fplll
cd fplll
./autogen.sh
./configure --prefix=$HOME/usr
make -j80
make install
```

```
git clone https://github.com/jacobkahn/flatter --branch fix_fplll_find
cmake -S . -B build -DCMAKE_PREFIX_PATH=$HOME/usr
cmake --build build --parallel
```
now succeeds