### PR TITLE
Some fixes for building with Apple clang on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.13)
 project(flatter LANGUAGES CXX)
 
 #flag
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 
 # includes
 LIST(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)

--- a/src/data/matrix/matrix_data_int64.cpp
+++ b/src/data/matrix/matrix_data_int64.cpp
@@ -1,6 +1,7 @@
 #include "data/matrix/matrix_data.h"
 
 #include <cassert>
+#include <cinttypes>
 #include <gmp.h>
 
 namespace flatter {
@@ -51,7 +52,7 @@ void MatrixData<int64_t>::fprint(FILE* f, const MatrixData<int64_t>& A) {
     for (unsigned int i = 0; i < A.nrows(); i++) {
         fprintf(f, "[");
         for (unsigned int j = 0; j < A.ncols(); j++) {
-            fprintf(f, "%ld ", A(i, j));
+            fprintf(f, "%" PRId64 " ", A(i, j));
         }
         fprintf(f, "]\n");
     }

--- a/src/problems/fused_qr_sizered/columnwise.cpp
+++ b/src/problems/fused_qr_sizered/columnwise.cpp
@@ -77,7 +77,6 @@ void Columnwise::solve() {
 
     for (unsigned int i = 0; i < n; i++) {
         bool must_repeat = false;
-        unsigned int iter = 0;
         double mu_max = INFINITY;
         do {
             // Check if size reduced
@@ -135,7 +134,6 @@ void Columnwise::solve() {
                 must_repeat = false;
             }
             mu_max = round_mu_max;
-            iter += 1;
             if (must_repeat) {
                 // Re orthogonalize
                 // Copy column from B to R

--- a/src/problems/lattice_reduction/goal.cpp
+++ b/src/problems/lattice_reduction/goal.cpp
@@ -1,5 +1,6 @@
 #include "problems/lattice_reduction/goal.h"
 
+#include <algorithm>
 #include <cassert>
 #include <cstdio>
 #include <cmath>
@@ -166,11 +167,11 @@ void LatticeReductionGoal::set_best_slope(double slope) {
     double s_guess = 3 * (1 + pow(3, lgn+1) - pow(2, lgn+2))/2;
     
     double gap = quality * s_guess / n;
-    double new_gap = gap + (this->best_slope - best_slope);
+    double new_gap = gap + (this->best_slope - slope);
     new_gap *= n;
     assert(new_gap > 0);
     this->quality = new_gap / s_guess;
-    this->best_slope = best_slope;
+    this->best_slope = slope;
 }
 
 LatticeReductionGoal LatticeReductionGoal::from_RHF(unsigned int n, double rhf, bool proved) {

--- a/src/problems/relative_size_reduction/orthogonal.cpp
+++ b/src/problems/relative_size_reduction/orthogonal.cpp
@@ -86,11 +86,9 @@ void Orthogonal::size_reduce(Matrix R, Matrix B, Matrix r_col, Matrix u_col, Mat
         mpz_set_ui(du_col(i, 0), 0);
     }
 
-    unsigned int iters = 0;
     int prev_max_mu = 1<<30;
 
     while (true) {
-        iters += 1;
         // Update the floating point R-factor based on the exact B column
         Matrix::copy(r_col, b_col);
         // Apply householder vectors to b

--- a/src/profile.cpp
+++ b/src/profile.cpp
@@ -1,5 +1,6 @@
 #include "data/lattice/profile.h"
 
+#include <algorithm>
 #include <cassert>
 #include <cmath>
 


### PR DESCRIPTION
- code uses C++17 features
- need `#include <algorithm>` for `std::max`
- use format specifier `PRId64` to accommodate `int64_t` being `long long`
- remove some unused variables
- fix warnings in `LatticeReductionGoal::set_best_slope` (looks like a bug)
