### PR TITLE
Fix initial profile for Irregular strategy

### DIFF
--- a/src/problems/lattice_reduction/irregular.cpp
+++ b/src/problems/lattice_reduction/irregular.cpp
@@ -162,14 +162,8 @@ bool Irregular::solve_triangular() {
     double* profile = new double[n];
     
     assert(M.type() == ElementType::MPZ);
-    double maxv, minv;
     MatrixData<mpz_t> dM = M.data<mpz_t>();
-    maxv = minv = mpz_sizeinbase(dM(0,0),2);
-    profile[0] = maxv;
-    for (unsigned int i = 1; i < n; i++) {
-        unsigned int sz = mpz_sizeinbase(dM(i,i),2);
-        maxv = std::max(maxv, (double)sz);
-        minv = std::min(minv, (double)sz);
+    for (unsigned int i = 0; i < n; i++) {
         long int exp;
         double d = mpz_get_d_2exp(&exp, dM(i,i));
         profile[i] = log2(fabs(d)) + exp;


### PR DESCRIPTION
When running the following:
```bash
latticegen q 4 2 181 p > lattice
FLATTER_LOG=log flatter -q lattice
```
(note: `181 = round(2^7.5)`)

I noticed the logfile logs the following profile initially:
```
Start 1730474921
R b5d9139f |Lattice Reduction|Irregular|d:3 prec:1 alpha:-1 P:-1|
profile(4)
R cf51e3ce |Size Reduction|ElementaryZZ|d:3 bits:1.58 P:-1|
T cf51e3ce 53401331 7771397a 1 12 {4 64} 0.000030
profile(0,4)[0.000111] 8.00+0.00 7.50+0.00 0.00+0.00 0.00+0.00
```

Here it (incorrectly) says `profile[0] = 8`. Instead, it should have said: `profile[0] = 7.50`.
After this pull request the output will be:

```
Start 1730475746
R 5659a776 |Lattice Reduction|Irregular|d:3 prec:1 alpha:-1 P:-1|
profile(4)
R 4b74e770 |Size Reduction|ElementaryZZ|d:3 bits:1.58 P:-1|
T 4b74e770 994c698c f760c6a2 1 12 {4 64} 0.000031
profile(0,4)[0.000110] 7.50+0.00 7.50+0.00 0.00+0.00 0.00+0.00 
```
