### PR TITLE
include,src: add missing <cstdint> includes

### DIFF
--- a/include/flatter/data/matrix/matrix.h
+++ b/include/flatter/data/matrix/matrix.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <mpfr.h>
 #include <memory>
 

--- a/src/data/matrix/matrix_data.cpp
+++ b/src/data/matrix/matrix_data.cpp
@@ -1,6 +1,7 @@
 #include "data/matrix/matrix_data.h"
 
 #include <cassert>
+#include <cstdint>
 #include <mpfr.h>
 
 namespace flatter {

--- a/src/data/matrix/workspace_buffer.cpp
+++ b/src/data/matrix/workspace_buffer.cpp
@@ -1,6 +1,7 @@
 #include "workspace_buffer.h"
 
 #include <cassert>
+#include <cstdint>
 #include <cstdlib>
 #include <mpfr.h>
 


### PR DESCRIPTION
Without this, the build fails on systems with the musl C library, though GCC is nice enough to tell you what to do:

```
.../include/flatter/data/matrix/matrix.h:7:1: note: 'int64_t' is
defined in header '<cstdint>'; this is probably fixable by adding
'#include <cstdint>'
    6 | #include "matrix_data.h"
  +++ |+#include <cstdint>
    7 |
```

(Any file using the int64_t type should `#include <cstdint>`)